### PR TITLE
Fixes from releasing core v0.6.0

### DIFF
--- a/sebex/popen.py
+++ b/sebex/popen.py
@@ -5,7 +5,7 @@ from typing import List, Union
 from sebex.log import logcontext, log, warn, error
 
 
-def popen(args: Union[str, PathLike, List[str]], log_stdout: bool = False,
+def popen(args: Union[str, PathLike, List[str]], log_stdout: bool = False, check = True,
           **kwargs) -> subprocess.CompletedProcess:
     if isinstance(args, str):
         lc = args
@@ -17,7 +17,7 @@ def popen(args: Union[str, PathLike, List[str]], log_stdout: bool = False,
     with logcontext(lc):
         try:
             proc = subprocess.run(args, stdin=subprocess.DEVNULL, capture_output=True,
-                                  check=True, encoding='utf-8', **kwargs)
+                                  check=check, encoding='utf-8', **kwargs)
             if log_stdout:
                 for line in proc.stdout.splitlines():
                     log(line)

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -202,7 +202,7 @@ class ReleaseState(ConfigFile, Checksumable):
 
                 # We have to release a new version of dependent if its relation
                 # points to soon-to-be-outdated version of the dependency.
-                if req.match(project.from_version) and not req.match(project.to_version):
+                if (req.match(project.from_version) or req.match(_previous_version(project.to_version))) and not req.match(project.to_version):
                     dep_bump = bumps[project.project].derive(project.from_version)
                     bumps[dependency] = max(bumps[dependency], dep_bump)
 
@@ -285,7 +285,6 @@ class ReleaseState(ConfigFile, Checksumable):
     @classmethod
     def _is_project_noop(cls, project: 'ProjectState') -> bool:
         if project.from_version == project.to_version:
-            assert not project.dependency_updates, f'Noop project {project!r} is in invalid state'
             return True
         else:
             return False

--- a/sebex_elixir_analyzer/lib/sebex_elixir_analyzer.ex
+++ b/sebex_elixir_analyzer/lib/sebex_elixir_analyzer.ex
@@ -29,6 +29,15 @@ defmodule Sebex.ElixirAnalyzer do
 
     dependencies = SourceAnalysis.Dependency.extract(ast)
 
+    if length(dependencies) != length(project_info[:deps]) do
+      raise """
+      Error detecting dependencies. Project dependencies:
+      #{inspect(project_info[:deps])}
+      found dependencies:
+      #{inspect(dependencies)}
+      """
+    end
+
     hex = HexInfo.fetch!(package_name)
 
     %AnalysisReport{

--- a/sebex_elixir_analyzer/lib/sebex_elixir_analyzer/source_analysis/dependency.ex
+++ b/sebex_elixir_analyzer/lib/sebex_elixir_analyzer/source_analysis/dependency.ex
@@ -5,7 +5,7 @@ defmodule Sebex.ElixirAnalyzer.SourceAnalysis.Dependency do
   @type t :: %__MODULE__{
           name: atom,
           version_spec: String.t() | map(),
-          version_spec_span: Span.t(),
+          version_spec_span: Span.t()
         }
 
   @derive Jason.Encoder
@@ -28,7 +28,7 @@ defmodule Sebex.ElixirAnalyzer.SourceAnalysis.Dependency do
 
         {kw_def, _,
          [
-           {:deps, _, nil},
+           {:deps, _, args},
            [
              {
                {:literal, _, [:do]},
@@ -37,7 +37,7 @@ defmodule Sebex.ElixirAnalyzer.SourceAnalysis.Dependency do
            ]
          ]} = t,
         :not_found
-        when kw_def in [:def, :defp] and is_list(deps_list) ->
+        when kw_def in [:def, :defp] and is_list(deps_list) and args in [[], nil] ->
           {:skip, t, {:found, deps_list}}
 
         t, :not_found ->


### PR DESCRIPTION
- elixir analyzer: handle  def deps() (with braces)
- allow opening PR even if updating deps fails
- automatically bump stale dependencies that depend on an already released project closes #16 