### PR TITLE
Output escript result in tags. Format code

### DIFF
--- a/sebex/language/elixir/__init__.py
+++ b/sebex/language/elixir/__init__.py
@@ -33,9 +33,12 @@ class ElixirLanguageSupport(LanguageSupport):
         return mix_file(project).exists()
 
     def analyze(self, project: ProjectHandle) -> AnalysisEntry:
+        import re
         with resources.path(__name__, 'elixir_analyzer') as elixir_analyzer:
             proc = popen([elixir_analyzer, '--mix', mix_file(project)])
-            raw = json.loads(proc.stdout)
+            analyzer_report = re.findall("<SEBEX_ELIXIR_ANALYZER_REPORT>(.*?)</SEBEX_ELIXIR_ANALYZER_REPORT>", proc.stdout, re.DOTALL)
+            analyzer_report = analyzer_report[0]
+            raw = json.loads(analyzer_report)
 
         package = raw['package']
         version = Version.parse(raw['version'])

--- a/sebex_elixir_analyzer/lib/sebex_elixir_analyzer/cli.ex
+++ b/sebex_elixir_analyzer/lib/sebex_elixir_analyzer/cli.ex
@@ -1,8 +1,11 @@
 defmodule Sebex.ElixirAnalyzer.CLI do
   def main(["--mix", path]) do
-    path
-    |> Sebex.ElixirAnalyzer.analyze_mix_exs_file!()
-    |> Jason.encode!()
+    analysis_report =
+      path
+      |> Sebex.ElixirAnalyzer.analyze_mix_exs_file!()
+      |> Jason.encode!()
+
+    ("<SEBEX_ELIXIR_ANALYZER_REPORT>" <> analysis_report <> "</SEBEX_ELIXIR_ANALYZER_REPORT>")
     |> IO.puts()
   end
 

--- a/sebex_elixir_analyzer/test/sebex_elixir_analyzer_test.exs
+++ b/sebex_elixir_analyzer/test/sebex_elixir_analyzer_test.exs
@@ -86,12 +86,12 @@ defmodule Sebex.ElixirAnalyzerTest do
                %Dependency{
                  name: :jason,
                  version_spec: "~> 1.1",
-                 version_spec_span: Span.new(17, 16, 17, 24),
+                 version_spec_span: Span.new(17, 16, 17, 24)
                },
                %Dependency{
                  name: :dialyxir,
                  version_spec: "~> 1.0.0-rc.7",
-                 version_spec_span: Span.new(18, 19, 18, 34),
+                 version_spec_span: Span.new(18, 19, 18, 34)
                },
                %Dependency{
                  name: :bunch,


### PR DESCRIPTION
Mix tasks can sometimes print something on the stdout. This fix adds tags for message we are printing so it's easy to fetch it from Python.