### PR TITLE
Multiple release sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,47 @@ Under the hood this will build Elixir analyzer script and place it in expected p
 
 To update your existing installation, invoke `make install` again.
 
+## Usage
+
+Make sure the repositories of your GitHub Organization are public. To allow Sebex to edit your repositories generate a GitHub [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and set it as your `TOKEN` environment variable or pass it with the `--github_access_token` option.
+
+### General workflow
+
+Add an organization by running:
+```
+sebex bootstrap -o sebex-test-organization
+```
+#todo talk about `sebex graph` and .sebex/profiles for excluding broken repos 
+
+Clone the organization's repositories to the local workspace:
+```
+sebex sync
+```
+Specify the package you'd like to update:
+```
+sebex release plan
+Project: sebex_test_x
+Version: 0.8.0
+```
+
+### Elixir
+
+Sebex will update Elixir package dependencies and versions automatically and release them on your GitHub. To publish those updated packages to [Hex](https://hex.pm/) you need to be logged in as an authorized Hex package maintainer on your machine. You can check your status by running:
+```
+mix hex.user whoami
+```
+
+You also need to set the `HEX_API_KEY` environment variable to your Hex user key. To generate the key run:
+```
+mix hex.user key generate
+```
+
+You will be alerted when trying to update a package and it's dependents without publishing it to Hex as the dependent packages won't be able to resolve their dependencies to the required but unpublished version by running `mix deps.get`.
+
+If you proceed anyway then the entire package dependency tree will later need to be published manually in order of the dependency relations.
 ## Development
 
-We use [Poetry] to manage a dependencies, virtual environments and builds. Run `poetry install` to install all dependencies. To build wheels run `make build`.
+We use [Poetry] to manage dependencies, virtual environments and builds. Run `poetry install` to install all dependencies. To build wheels run `make build`.
 
 Python tests are run using pytest, run `pytest` inside `poetry shell` to execute them. To run Elixir analyzer test, run `mix test` within its directory.
 

--- a/sebex/analysis/database.py
+++ b/sebex/analysis/database.py
@@ -3,10 +3,12 @@ from typing import Dict, Iterable, Tuple, Optional
 
 import click
 
-from sebex.analysis.model import Language, AnalysisError, AnalysisEntry
-from sebex.config.manifest import ProjectHandle
+from sebex.edit.span import Span
+from sebex.analysis.version import Version, VersionSpec, VersionRequirement, Pin
+from sebex.analysis.model import Language, AnalysisError, AnalysisEntry, Release, Dependency
+from sebex.config.manifest import ProjectHandle, RepositoryHandle
 from sebex.jobs import for_each
-from sebex.language import detect_language, language_support_for
+from sebex.language import detect_language, language_support_for, Language
 from sebex.log import operation
 
 _Projects = Dict[ProjectHandle, Tuple[Language, AnalysisEntry]]
@@ -14,7 +16,7 @@ _PackageNameIndex = Dict[str, ProjectHandle]
 
 _UNKNOWN_LANGUAGE = click.style('UNKNOWN LANGUAGE', fg='yellow')
 
-
+VIRTUAL_NODE = '__virtual_root_node_project__'
 @dataclass(eq=False)
 class AnalysisDatabase:
     _projects: _Projects
@@ -48,12 +50,14 @@ class AnalysisDatabase:
             raise AnalysisError(f'Project not found: "{project}". Make sure projects are synced via `sebex sync`.')
 
     @classmethod
-    def collect(cls, projects: Iterable[ProjectHandle]) -> 'AnalysisDatabase':
+    def collect(cls, projects: Iterable[ProjectHandle], bumps: dict[ProjectHandle, Version]=None) -> 'AnalysisDatabase':
         projects = list(projects)
         projects = zip(projects, for_each(projects, cls._do_collect, desc='Analyzing'))
         # Filter out ignored
         projects = filter(lambda t: t[1][1], projects)
         projects = dict(projects)
+        if bumps is not None:
+            projects = cls._add_virtual_root(projects, bumps)
         return cls._analyze(projects)
 
     @classmethod
@@ -85,3 +89,30 @@ class AnalysisDatabase:
             else:
                 raise AnalysisError(f'Duplicate package name: "{entry.package}"')
         return index
+
+    @classmethod
+    def _add_virtual_root(cls, projects: dict[ProjectHandle], bumps: dict[ProjectHandle, Version]) -> dict[ProjectHandle]:
+        # create a fake package `VIRTUAL_NODE` with version 0.1.0
+        project = ProjectHandle(RepositoryHandle(VIRTUAL_NODE))
+        analysis_entry = AnalysisEntry(
+            VIRTUAL_NODE,
+            Version(0, 1, 0),
+            Span(0, 0, 0, 0),
+            [],
+            [Release(Version(0, 1, 0))])
+        projects[project] = (Language.ELIXIR, analysis_entry)
+        # for all packages to be released add a dependency to the virtual package
+        # this places it at the root of the dependency graph of all updated packages
+        for project, _version in bumps.items():
+            _language, analysis_entry = projects[project]
+            dependency = Dependency(
+                        name=VIRTUAL_NODE, 
+                        defined_in=str(project), 
+                        version_spec=VersionSpec(
+                            value=VersionRequirement(
+                                operator='~>', 
+                                base=Version(0, 1, 0), 
+                                pin=Pin.MINOR)), 
+                        version_spec_span=Span(start_line=0, start_column=0, end_line=0, end_column=0))
+            analysis_entry.dependencies.append(dependency)
+        return projects

--- a/sebex/analysis/model.py
+++ b/sebex/analysis/model.py
@@ -53,7 +53,8 @@ class AnalysisEntry:
 
     @property
     def is_published(self) -> bool:
-        return bool(self.releases)
+        # always publish test packages
+        return bool(self.releases) or 'sebex_test' in self.package
 
 
 @dataclass

--- a/sebex/analysis/state.py
+++ b/sebex/analysis/state.py
@@ -1,3 +1,5 @@
+from sebex.analysis.version import Version
+from sebex.config.manifest import ProjectHandle
 from typing import Tuple
 
 from sebex.analysis.database import AnalysisDatabase
@@ -5,7 +7,7 @@ from sebex.analysis.graph import DependentsGraph
 from sebex.config.profile import current_project_handles
 
 
-def analyze() -> Tuple[AnalysisDatabase, DependentsGraph]:
-    database = AnalysisDatabase.collect(current_project_handles())
+def analyze(bumps: dict[ProjectHandle, Version] = None) -> Tuple[AnalysisDatabase, DependentsGraph]:
+    database = AnalysisDatabase.collect(current_project_handles(), bumps)
     graph = DependentsGraph.build(database)
     return database, graph

--- a/sebex/cmd/release.py
+++ b/sebex/cmd/release.py
@@ -33,8 +33,9 @@ def status():
 
 def gather_input() -> dict[Version, ProjectHandle]:
     bumps = {}
+    log("hit enter when done", color='yellow')
     while True:
-        value = click.prompt("Project name (hit enter to stop)", default="", show_default=False)
+        value = click.prompt("Project", default="", show_default=False)
         if value == "":
             break
         project = valid_project(value)
@@ -81,6 +82,7 @@ def plan(dry: bool):
 
     # gather project names of packages to be released
     bumps = gather_input()
+    assert len(bumps) > 0
 
     if not dry:
         if ReleaseState.exists():

--- a/sebex/language/elixir/__init__.py
+++ b/sebex/language/elixir/__init__.py
@@ -103,7 +103,10 @@ class ElixirLanguageSupport(LanguageSupport):
             return False
 
         with operation('Publishing for real'):
-            proc = popen(['mix', 'hex.publish', '--yes'], log_stdout=True, cwd=project.location)
+            if 'sebex_test' in str(project):
+                proc = popen(['mix', 'hex.publish', '--yes', '--replace'], log_stdout=True, cwd=project.location)
+            else:
+                proc = popen(['mix', 'hex.publish', '--yes'], log_stdout=True, cwd=project.location)
 
             # https://github.com/hexpm/hex/blob/3362c4abea51525d6c435ebb30bacfa603e0213a/lib/mix/tasks/hex.publish.ex#L536
             if 'Package published to ' in proc.stdout:

--- a/sebex/popen.py
+++ b/sebex/popen.py
@@ -21,6 +21,8 @@ def popen(args: Union[str, PathLike, List[str]], log_stdout: bool = False, check
             if log_stdout:
                 for line in proc.stdout.splitlines():
                     log(line)
+                for line in proc.stderr.splitlines():
+                    log(line)
             return proc
         except subprocess.CalledProcessError as e:
             if e.stdout:

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -141,6 +141,9 @@ class ReleaseState(ConfigFile, Checksumable):
         hasher(self.sources)
         hasher(self.phases)
 
+
+
+siema
     @classmethod
     def plan(cls, project: ProjectHandle, to_version: Version,
              db: AnalysisDatabase, graph: DependentsGraph) -> 'ReleaseState':
@@ -197,8 +200,8 @@ class ReleaseState(ConfigFile, Checksumable):
         # Here we go
         for project, dependency, relation in self._dependency_relations(db, graph):
             print()
-            print("project: ", project.project, project.to_version)
-            # print("dependency: ", dependency)
+            print("project: ", project.project)
+            print("dependency: ", dependency)
             # We need to handle each dependency kind (version req, git, path) separately
             if relation.version_spec.is_version:
                 req: VersionRequirement = relation.version_spec.value
@@ -210,7 +213,6 @@ class ReleaseState(ConfigFile, Checksumable):
 
                     update = relation.prepare_update(VersionSpec.targeting(project.to_version))
                     dependency_updates[dependency].append(update)
-                    # do the upate'ing:
                     for phase in self.phases:
                         for project in phase:
                             if project.project in self.sources:
@@ -243,8 +245,6 @@ class ReleaseState(ConfigFile, Checksumable):
         for lst in dependency_updates.values():
             lst.sort(key=lambda u: u.name)
 
-        print("\n\nbumps:\n")
-
         # Apply found version bumps to projects
         for phase in self.phases:
             for project in phase:
@@ -254,8 +254,6 @@ class ReleaseState(ConfigFile, Checksumable):
                     project.to_version = bumps[project.project].apply(project.from_version)
 
                 project.dependency_updates = dependency_updates[project.project]
-                print()
-                print(project.project, project.to_version)
 
 
     def _dependency_relations(

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -141,9 +141,6 @@ class ReleaseState(ConfigFile, Checksumable):
         hasher(self.sources)
         hasher(self.phases)
 
-
-
-siema
     @classmethod
     def plan(cls, project: ProjectHandle, to_version: Version,
              db: AnalysisDatabase, graph: DependentsGraph) -> 'ReleaseState':
@@ -200,8 +197,8 @@ siema
         # Here we go
         for project, dependency, relation in self._dependency_relations(db, graph):
             print()
-            print("project: ", project.project)
-            print("dependency: ", dependency)
+            print("project: ", project.project, project.to_version)
+            # print("dependency: ", dependency)
             # We need to handle each dependency kind (version req, git, path) separately
             if relation.version_spec.is_version:
                 req: VersionRequirement = relation.version_spec.value
@@ -213,6 +210,7 @@ siema
 
                     update = relation.prepare_update(VersionSpec.targeting(project.to_version))
                     dependency_updates[dependency].append(update)
+                    # do the upate'ing:
                     for phase in self.phases:
                         for project in phase:
                             if project.project in self.sources:
@@ -245,6 +243,8 @@ siema
         for lst in dependency_updates.values():
             lst.sort(key=lambda u: u.name)
 
+        print("\n\nbumps:\n")
+
         # Apply found version bumps to projects
         for phase in self.phases:
             for project in phase:
@@ -254,6 +254,8 @@ siema
                     project.to_version = bumps[project.project].apply(project.from_version)
 
                 project.dependency_updates = dependency_updates[project.project]
+                print()
+                print(project.project, project.to_version)
 
 
     def _dependency_relations(


### PR DESCRIPTION
#5

This solution works by creating a virtual project which is injected as a dependency for all of the sources specified by the user. Release planning is then run starting from this root node.
The solution is suboptimal in the following ways:
- it ignores the `ReleaseState.sources` groundwork
- projects are always bumped one minor version forwards i.e 0.4.3 -> 0.5.0.