### PR TITLE
Update obsolete packages automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ sebex release proceed
 
 for each phase of the plan.
 
+If at this point you encounter an error while releasing any phase of the plan there is no need to rerun `sebex release plan`. Instead run `sebex release proceed` after you've fixed the issue causing that phase to fail. Sebex will continue where you left off.
+
 ### Elixir
 
 At the moment Elixir is the only supported language.

--- a/README.md
+++ b/README.md
@@ -22,34 +22,44 @@ To update your existing installation, invoke `make install` again.
 
 Make sure the repositories of your GitHub Organization are public. To allow Sebex to edit your repositories generate a GitHub [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and set it as your `TOKEN` environment variable or pass it with the `--github_access_token` option.
 
-#### Preparation
+### Preparation
 
 It's advisable to use the `--profile` and `--workspace` options when running Sebex or to set env vars `SEBEX_PROFILE` and `SEBEX_WORKSPACE`
 
 To add an organization run:
+
 ```bash
 sebex bootstrap -o sebex-test-organization
 ```
+
 This will create the `manifest.yaml` listing all public repositories in that organization. To exclude broken or unsupported repositories from further analysis add a new line containing `!project_name` to your `workspace_directory/profiles/your_profile.txt` file.
 
 To perform further work Sebex must clone your organization's repositories to your local workspace:
+
 ```bash
 sebex sync
 ```
+
 You can view the dependency graph of your projects:
+
 ```bash
 sebex graph --view
 ```
-#### Releasing packages
+
+### Releasing packages
+
 Prepare a release plan by listing the project names of the packages you want to release:
+
 ```bash
 sebex release plan
 Project: sebex_test_b
 Project: sebex_test_e
 Project:
 ```
+
 All listed packages as well as their dependent packages will be bumped by one minor version (e.g. 0.2.1 -> 0.3.0).
 Review if you're happy with the suggested release plan and save it.
+
 ```
 Release "Purely Easy Wahoo"
 ===========================
@@ -70,27 +80,33 @@ Release "Purely Easy Wahoo"
 
 Save this release? [y/N]:
 ```
+
 To execute the plan run:
+
 ```bash
 sebex release proceed
 ```
+
 for each phase of the plan.
-#### Elixir
+
+### Elixir
 
 At the moment Elixir is the only supported language.
 
 Sebex will modify your Elixir projects by updating your project version and dependencies in the `mix.exs` file. Those changes will be commited to Github and tagged as a version release. To publish those updated packages to [Hex](https://hex.pm/) you need to be logged in as an authorized Hex package maintainer on your machine.
 
 You also need to set the `HEX_API_KEY` environment variable to your Hex user key. To generate the key run:
+
 ```bash
 mix hex.user key generate
 ```
 
 Only packages that were released at least once will be published automatically by Sebex to avoid publishing work-in-progress projects.
 However packages belonging to the Github `sebex-test-organization` will always be published.
+
 ## Development
 
-We use [Poetry] to manage dependencies, virtual environments and builds. Run `poetry install` to install all dependencies. To build wheels run `make build`.
+We use [Poetry] to manage dependencies, virtual environments and builds. Run `poetry install` to install all dependencies. To build wheels run `make build` .
 
 Python tests are run using pytest, run `pytest` inside `poetry shell` to execute them. To run Elixir analyzer test, run `mix test` within its directory.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ To disable updating of obsolete packages run:
 sebex release plan --no-update
 ```
 
+Example output of `sebex release plan`:
+
 ```
 Release "Purely Easy Wahoo"
 ===========================

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ mix hex.user key generate
 
 Only packages that were released at least once will be published automatically by Sebex to avoid publishing work-in-progress projects.
 
+To publish a package that has not yet been published to hex you can edit the `force-publish` field in your `manifest.yaml` file.
+
 ## Development
 
 We use [Poetry] to manage dependencies, virtual environments and builds. Run `poetry install` to install all dependencies. To build wheels run `make build` .

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Project:
 All listed packages as well as their dependent packages will be bumped by one minor version (e.g. 0.2.1 -> 0.3.0).
 Review if you're happy with the suggested release plan and save it.
 
+Sebex will warn you if there are obsolete dependencies in your packages. By default they will be updated anyway.
+To disable updating of obsolete packages run:
+
+```bash
+sebex release plan --no-update
+```
+
 ```
 Release "Purely Easy Wahoo"
 ===========================

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ mix hex.user key generate
 ```
 
 Only packages that were released at least once will be published automatically by Sebex to avoid publishing work-in-progress projects.
-However packages belonging to the Github `sebex-test-organization` will always be published.
 
 ## Development
 

--- a/sebex/analysis/database.py
+++ b/sebex/analysis/database.py
@@ -82,5 +82,5 @@ class AnalysisDatabase:
             if entry.package not in index:
                 index[entry.package] = project
             else:
-                raise AnalysisError(f'Duplicate package name: "{entry.package}"')
+                raise AnalysisError(f'Duplicate package name: "{entry.package}" in {project}')
         return index

--- a/sebex/analysis/model.py
+++ b/sebex/analysis/model.py
@@ -53,8 +53,7 @@ class AnalysisEntry:
 
     @property
     def is_published(self) -> bool:
-        # always publish test packages
-        return bool(self.releases) or 'sebex_test' in self.package
+        return bool(self.releases)
 
 
 @dataclass

--- a/sebex/analysis/state.py
+++ b/sebex/analysis/state.py
@@ -7,7 +7,7 @@ from sebex.analysis.graph import DependentsGraph
 from sebex.config.profile import current_project_handles
 
 
-def analyze(bumps: dict[ProjectHandle, Version] = None) -> Tuple[AnalysisDatabase, DependentsGraph]:
-    database = AnalysisDatabase.collect(current_project_handles(), bumps)
+def analyze() -> Tuple[AnalysisDatabase, DependentsGraph]:
+    database = AnalysisDatabase.collect(current_project_handles())
     graph = DependentsGraph.build(database)
     return database, graph

--- a/sebex/cli.py
+++ b/sebex/cli.py
@@ -3,12 +3,26 @@ import click
 from sebex.analysis.version import Version
 from sebex.config.manifest import ProjectHandle, Manifest
 from sebex.context import Context
+from typing import Tuple
 
 
-class ProjectType(click.ParamType):
-    name = "project"
+class SourceType(click.ParamType):
+    name = "source"
 
-    def convert(self, value, param, ctx):
+    def convert(self, value, param, ctx) -> Tuple[Version, ProjectHandle]:
+        project_str, version_str = self._parse_source(value, param, ctx)
+        project = self._validate_project(project_str, param, ctx)
+        version = self._validate_version(version_str, param, ctx)
+        return project, version
+
+    def _parse_source(self, value, param, ctx):
+        try:
+            project_str, version_str = value.split(':')
+            return project_str, version_str
+        except ValueError:
+            self.fail(f'{value}\nthe source format should be `<project>:<version>` i.e. `membrane_framework:0.8.0`', param, ctx)
+
+    def _validate_project(self, value, param, ctx) -> ProjectHandle:
         try:
             handle = ProjectHandle.parse(value)
         except ValueError:
@@ -23,21 +37,13 @@ class ProjectType(click.ParamType):
 
         self.fail(f'Unknown project {handle}')
 
-
-PROJECT = ProjectType()
-
-
-class VersionType(click.ParamType):
-    name = "version"
-
-    def convert(self, value, param, ctx):
+    def _validate_version(self, value, param, ctx) -> Version:
         try:
             return Version.parse(value)
         except ValueError:
-            self.fail(f'{value!r} is not a valid version')
+            self.fail(f'{value!r} is not a valid version', param, ctx)
 
-
-VERSION = VersionType()
+SOURCE = SourceType()
 
 
 def confirm(text: str) -> bool:

--- a/sebex/cmd/release.py
+++ b/sebex/cmd/release.py
@@ -7,7 +7,8 @@ from sebex.config.manifest import ProjectHandle, Manifest
 from sebex.log import success, log, fatal, operation, warn
 from sebex.release.executor import Action, plan as execute_plan, proceed as proceed_plan
 from sebex.release.state import ReleaseState
-from typing import Optional
+from typing import Optional, Dict
+
 
 @click.group()
 def release():
@@ -29,6 +30,7 @@ def status():
         log(rel.describe())
     else:
         success('There is no release pending at this moment, feel free to start one.')
+
 
 def gather_input() -> Dict[Version, ProjectHandle]:
     sources = {}
@@ -52,12 +54,14 @@ def gather_input() -> Dict[Version, ProjectHandle]:
                 break
     return sources
 
+
 def valid_version(value: str) -> Optional[Version]:
     try:
         return Version.parse(value)
     except ValueError:
         print(f'{value!r} is not a valid version')
         return None
+
 
 def valid_project(value: str) -> Optional[ProjectHandle]:
     try:
@@ -71,6 +75,7 @@ def valid_project(value: str) -> Optional[ProjectHandle]:
                 return project
     print(f'Unknown project {handle}')
     return None
+
 
 @release.command()
 @click.option('--dry', is_flag=True,
@@ -128,7 +133,8 @@ def proceed(dry: bool):
                 with operation('Removing release state file'):
                     rel.delete()
             else:
-                success(f'The phase "{rel.current_phase().codename()}" has finished successfully!')
+                success(
+                    f'The phase "{rel.current_phase().codename()}" has finished successfully!')
                 warn('To proceed, rerun this command.')
         elif action == Action.BREAKPOINT:
             warn('A breakpoint has been reached!')

--- a/sebex/cmd/release.py
+++ b/sebex/cmd/release.py
@@ -2,12 +2,12 @@ import click
 
 from sebex.analysis.state import analyze
 from sebex.analysis.version import Version
-from sebex.cli import PROJECT, VERSION, confirm
+from sebex.cli import confirm, SOURCE
 from sebex.config.manifest import ProjectHandle, Manifest
 from sebex.log import success, log, fatal, operation, warn
 from sebex.release.executor import Action, plan as execute_plan, proceed as proceed_plan
 from sebex.release.state import ReleaseState
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
 
 
 @click.group()
@@ -80,13 +80,19 @@ def valid_project(value: str) -> Optional[ProjectHandle]:
 @release.command()
 @click.option('--dry', is_flag=True,
               help='Print what would be done, but do not persist the generated plan.')
-def plan(dry: bool):
+@click.option('--source', '-s', multiple=True, type=SOURCE)
+def plan(dry: bool, source):
     """
     Prepare release plan for managed packages.
     """
 
-    # gather project names of packages to be released
-    sources = gather_input()
+    # gather project names of packages to be released if none were passed via --source option
+    sources = {}
+    if source == ():
+        sources = gather_input()
+    else:
+        for p, v in source:
+            sources[p] = v
 
     if not dry:
         if ReleaseState.exists():

--- a/sebex/cmd/release.py
+++ b/sebex/cmd/release.py
@@ -80,8 +80,10 @@ def valid_project(value: str) -> Optional[ProjectHandle]:
 @release.command()
 @click.option('--dry', is_flag=True,
               help='Print what would be done, but do not persist the generated plan.')
+@click.option('--update/--no-update', is_flag=True, default=True,
+              help='Should packages depending on obsolete versions of other packages be updated?')
 @click.option('--source', '-s', multiple=True, type=SOURCE)
-def plan(dry: bool, source):
+def plan(dry: bool, update: bool, source):
     """
     Prepare release plan for managed packages.
     """
@@ -101,7 +103,7 @@ def plan(dry: bool, source):
                   'Please finish it before creating new one.')
 
     database, graph = analyze()
-    rel = ReleaseState.plan(sources, database, graph)
+    rel = ReleaseState.plan(sources, database, graph, update)
 
     log()
     log(rel.describe())

--- a/sebex/config/manifest.py
+++ b/sebex/config/manifest.py
@@ -14,7 +14,8 @@ from sebex.name_similarity import sorting_key, REPO_NAME_SIMILARITY
 if TYPE_CHECKING:
     from sebex.vcs import Vcs
 
-_GITHUB_SSH_URL = re.compile(r'git@github\.com:(?P<full>(?P<org>[^/]+)/(?P<repo>.+))\.git/?')
+_GITHUB_SSH_URL = re.compile(
+    r'git@github\.com:(?P<full>(?P<org>[^/]+)/(?P<repo>.+))\.git/?')
 
 
 @dataclass(order=True, unsafe_hash=True)
@@ -117,6 +118,7 @@ class ProjectManifest:
 class RepositoryManifest:
     name: str
     remote_url: str
+    force_publish: bool
     projects: List[ProjectManifest]
     default_branch: str = 'master'
 
@@ -149,7 +151,7 @@ class RepositoryManifest:
             raise ValueError('Repository is not hosted on GitHub')
 
     def to_raw(self) -> Dict:
-        d = {'name': self.name, 'remote_url': self.remote_url}
+        d = {'name': self.name, 'remote_url': self.remote_url, 'force_publish': False}
 
         if not (len(self.projects) == 1 and self.projects[0].is_root):
             d['projects'] = [ProjectManifest.to_raw(p) for p in self.projects]
@@ -162,19 +164,26 @@ class RepositoryManifest:
     @staticmethod
     def from_raw(raw: Dict) -> 'RepositoryManifest':
         projects = [ProjectManifest.from_raw(r) for r in raw.get('projects', [{'path': '.'}])]
-        return RepositoryManifest(name=raw['name'], remote_url=raw['remote_url'], projects=projects,
-                                  default_branch=raw.get('default_branch', 'master'))
+        return RepositoryManifest(name=raw['name'], remote_url=raw['remote_url'], force_publish=raw['force_publish'],
+                                  projects=projects, default_branch=raw.get('default_branch', 'master'))
 
     @staticmethod
     def from_github_repository(repo: GithubRepository) -> 'RepositoryManifest':
-        return RepositoryManifest(name=repo.name, remote_url=repo.ssh_url,
+        return RepositoryManifest(name=repo.name, remote_url=repo.ssh_url, force_publish=False,
                                   projects=[ProjectManifest()], default_branch=repo.default_branch)
 
 
 class Manifest(ConfigFile):
     _name = 'manifest'
     _data = {
-        'repositories': []
+        'repositories': [],
+        'config': {
+            'hex':
+            {
+                'allow_replace_on_publish': False,
+                'force_publish_all': False
+            }
+        }
     }
 
     _repository_index: Dict[str, int]
@@ -186,6 +195,18 @@ class Manifest(ConfigFile):
 
     def _rebuild_repository_index(self):
         self._repository_index = {r['name']: i for i, r in enumerate(self._data['repositories'])}
+
+    @property
+    def allow_replace_on_publish(self) -> bool:
+        return self._data['config']['hex']['allow_replace_on_publish']
+
+    @property
+    def force_publish_all(self) -> bool:
+        return self._data['config']['hex']['force_publish_all']
+
+    def force_publish(self, name: Union[str, RepositoryHandle]) -> bool:
+        repo = self.get_repository_by_name(name)
+        return repo.force_publish
 
     def get_repository_by_name(self, name: Union[str, RepositoryHandle]) -> RepositoryManifest:
         repo = self.find_repository_by_name(name)

--- a/sebex/config/manifest.py
+++ b/sebex/config/manifest.py
@@ -180,8 +180,7 @@ class Manifest(ConfigFile):
         'config': {
             'hex':
             {
-                'allow_replace_on_publish': False,
-                'force_publish_all': False
+                'allow_replace_on_publish': False
             }
         }
     }
@@ -199,10 +198,6 @@ class Manifest(ConfigFile):
     @property
     def allow_replace_on_publish(self) -> bool:
         return self._data['config']['hex']['allow_replace_on_publish']
-
-    @property
-    def force_publish_all(self) -> bool:
-        return self._data['config']['hex']['force_publish_all']
 
     def force_publish(self, name: Union[str, RepositoryHandle]) -> bool:
         repo = self.get_repository_by_name(name)

--- a/sebex/edit/patch.py
+++ b/sebex/edit/patch.py
@@ -23,7 +23,7 @@ def patch_readme(file: Path, project: str, to_version: str):
 
 
 def _patch_readme_line(line, project, to_version):
-    project = project.replace('-', '_')
+    project = project.replace('-', '_') #! temporary fix until github repo names are made consistent
     whitespace = re.match(whitespace_pattern, line).group()
     if f'{{:{project}, "' in line and re.search(version_pattern, line):
         return f'{whitespace}{{:{project}, "~> {to_version}"}}\n'

--- a/sebex/edit/patch.py
+++ b/sebex/edit/patch.py
@@ -9,6 +9,8 @@ from sebex.edit.span import Span
 Patch = Tuple[Span, str]
 Point = Tuple[int, int]
 
+version_pattern = re.compile(r'".*\d+\.\d+[\.\d+]?.*"')
+whitespace_pattern = re.compile(r"\s*")
 
 def patch_readme(file: Path, project: str, to_version: str):
     new_lines = []
@@ -21,9 +23,11 @@ def patch_readme(file: Path, project: str, to_version: str):
 
 
 def _patch_readme_line(line, project, to_version):
-    pattern = re.compile(r'".*\d+\.\d+[\.\d+]?.*"')
-    whitespace = re.match(r"\s*", line).group()
-    if f'{{:{project}, "' in line and re.search(pattern, line):
+    project = project.replace('-', '_')
+    whitespace = re.match(whitespace_pattern, line).group()
+    if f'{{:{project}, "' in line and re.search(version_pattern, line):
+        print("line:", line)
+        print(f'return: {whitespace}{{:{project}, "~> {to_version}"}}')
         return f'{whitespace}{{:{project}, "~> {to_version}"}}\n'
     else:
         return line

--- a/sebex/edit/patch.py
+++ b/sebex/edit/patch.py
@@ -21,7 +21,7 @@ def patch_readme(file: Path, project: str, to_version: str):
 
 
 def _patch_readme_line(line, project, to_version):
-    pattern = re.compile(r'".*\d+\.\d+\.\d+.*"')
+    pattern = re.compile(r'".*\d+\.\d+[\.\d+]?.*"')
     if f'{{:{project}, "' in line and re.search(pattern, line):
         return f'\t{{:{project}, "~> {to_version}"}}\n'
     else:

--- a/sebex/edit/patch.py
+++ b/sebex/edit/patch.py
@@ -22,8 +22,9 @@ def patch_readme(file: Path, project: str, to_version: str):
 
 def _patch_readme_line(line, project, to_version):
     pattern = re.compile(r'".*\d+\.\d+[\.\d+]?.*"')
+    whitespace = re.match(r"\s*", line).group()
     if f'{{:{project}, "' in line and re.search(pattern, line):
-        return f'\t{{:{project}, "~> {to_version}"}}\n'
+        return f'{whitespace}{{:{project}, "~> {to_version}"}}\n'
     else:
         return line
 

--- a/sebex/edit/patch.py
+++ b/sebex/edit/patch.py
@@ -26,8 +26,6 @@ def _patch_readme_line(line, project, to_version):
     project = project.replace('-', '_')
     whitespace = re.match(whitespace_pattern, line).group()
     if f'{{:{project}, "' in line and re.search(version_pattern, line):
-        print("line:", line)
-        print(f'return: {whitespace}{{:{project}, "~> {to_version}"}}')
         return f'{whitespace}{{:{project}, "~> {to_version}"}}\n'
     else:
         return line

--- a/sebex/edit/patch.py
+++ b/sebex/edit/patch.py
@@ -2,11 +2,30 @@ from collections import defaultdict
 from io import StringIO
 from pathlib import Path
 from typing import Tuple, Iterable, TextIO, Iterator, Dict, Optional
+import re
 
 from sebex.edit.span import Span
 
 Patch = Tuple[Span, str]
 Point = Tuple[int, int]
+
+
+def patch_readme(file: Path, project: str, to_version: str):
+    new_lines = []
+    with open(file, 'r') as f:
+        lines = f.readlines()
+        for line in lines:
+            new_lines.append(_patch_readme_line(line, project, to_version))
+    with open(file, 'w') as f:
+        f.writelines(new_lines)
+
+
+def _patch_readme_line(line, project, to_version):
+    pattern = re.compile(r'".*\d+\.\d+\.\d+.*"')
+    if f'{{:{project}, "' in line and re.search(pattern, line):
+        return f'\t{{:{project}, "~> {to_version}"}}\n'
+    else:
+        return line
 
 
 def patch_file(file: Path, patches: Iterable[Patch]):

--- a/sebex/language/elixir/__init__.py
+++ b/sebex/language/elixir/__init__.py
@@ -11,7 +11,7 @@ from sebex.config.manifest import Manifest, ProjectHandle
 from sebex.edit.patch import patch_file, patch_readme
 from sebex.edit.span import Span
 from sebex.language.abc import LanguageSupport
-from sebex.log import operation, warn, fatal
+from sebex.log import operation, warn, fatal, error
 from sebex.popen import popen
 
 
@@ -83,8 +83,11 @@ class ElixirLanguageSupport(LanguageSupport):
             project.repo.vcs.commit(f'bump to {to_version}', [mix_file(project)])
 
         with operation('Update README.md'):
-            patch_readme(readme_file(project), str(project), str(to_version))
-            project.repo.vcs.commit(f'update readme', [readme_file(project)])
+            try:
+                patch_readme(readme_file(project), str(project), str(to_version))
+                project.repo.vcs.commit(f'update readme', [readme_file(project)])
+            except:
+                error("Updating README.md failed. Skipping - you need to update it manually.")
 
 
         if project.repo.vcs.is_tracked(mix_lock(project)):

--- a/sebex/language/elixir/__init__.py
+++ b/sebex/language/elixir/__init__.py
@@ -7,7 +7,7 @@ from typing import List
 from sebex.analysis.model import AnalysisEntry, Dependency, Release, Language, DependencyUpdate
 from sebex.analysis.version import VersionSpec, Version
 from sebex.cli import confirm
-from sebex.config.manifest import ProjectHandle
+from sebex.config.manifest import Manifest, ProjectHandle
 from sebex.edit.patch import patch_file
 from sebex.edit.span import Span
 from sebex.language.abc import LanguageSupport
@@ -103,7 +103,7 @@ class ElixirLanguageSupport(LanguageSupport):
             return False
 
         with operation('Publishing for real'):
-            if 'sebex_test' in str(project):
+            if Manifest.open().allow_replace_on_publish:
                 proc = popen(['mix', 'hex.publish', '--yes', '--replace'], log_stdout=True, cwd=project.location)
             else:
                 proc = popen(['mix', 'hex.publish', '--yes'], log_stdout=True, cwd=project.location)

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -213,7 +213,7 @@ class ReleaseState(ConfigFile, Checksumable):
                 if release_new_version or update_package:
                     # if a dependency of the package changed it's MINOR or MAJOR version then bump dependent by MINOR
                     req_bump = Bump.MINOR if update_package else Bump.STAY_AS_IS
-                    dep_bump = Bump.between(project.from_version, project.to_version)
+                    dep_bump = Bump.between(project.from_version, project.to_version)#!.derive(project.from_version)
                     bumps[dependency] = max(req_bump, dep_bump)
 
                     update = relation.prepare_update(VersionSpec.targeting(project.to_version))
@@ -227,6 +227,8 @@ class ReleaseState(ConfigFile, Checksumable):
                         dependent_project.to_version = bumps[dependency].apply(dependent_project.from_version)
 
                 if package_is_obsolete:
+                    #! accumulate obsolete `dependency`, `project.to_version`
+                    dependency_bumps[dependency].append({project.project, req_from_version(project.to_version)})
                     warn(f'Project {dependency} depends on an obsolete version '
                          f'of {project.project} (current version is {project.to_version}, '
                          f'while dependency requirement is {req}).')

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -429,8 +429,7 @@ class ProjectState(Checksumable):
         about = db.about(project)
         manifest = Manifest.open()
         publish = about.is_published or \
-                  manifest.force_publish(project.repo) or \
-                  manifest.force_publish_all
+                  manifest.force_publish(project.repo)
         return cls(
             project=project,
             from_version=about.version,

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -7,7 +7,7 @@ from typing import List, Iterator, Collection, Iterable, Dict, Tuple, Set
 
 import click
 
-from sebex.analysis.database import VIRTUAL_NODE, AnalysisDatabase
+from sebex.analysis.database import AnalysisDatabase
 from sebex.analysis.graph import DependentsGraph
 from sebex.analysis.model import Dependency, Language, DependencyUpdate
 from sebex.analysis.version import Bump, VersionRequirement, VersionSpec, Version, UnsolvableBump
@@ -142,43 +142,43 @@ class ReleaseState(ConfigFile, Checksumable):
         hasher(self.phases)
 
     @classmethod
-    def plan(cls, project: ProjectHandle, to_version: Version,
-             db: AnalysisDatabase, graph: DependentsGraph) -> 'ReleaseState':
+    def plan(cls, sources: Dict[ProjectHandle, Version], db: AnalysisDatabase, graph: DependentsGraph) -> 'ReleaseState':
         with operation('Constructing release plan'):
-            about_project = db.about(project)
-            from_version = about_project.version
-
-            if from_version > to_version:
-                # We are backporting bug fixes to older releases than the current one.
-                raise NotImplementedError('backports are not implemented yet')
-
-            # We are making a brand-new release
-            sources = {project: to_version}
             ignore = set()
+            allPhases = []
 
-            phases = graph.upgrade_phases(about_project.package)
-            phases = (
-                (db.get_project_by_package(pkg) for pkg in sorted(phase))
-                for phase in phases
-            )
-            phases = [PhaseState.clean(projs, db) for projs in phases]
-            assert len(phases) > 0
+            for project, to_version in sources.items():
+                about_project = db.about(project)
+                from_version = about_project.version
 
-            rel = cls(sources=sources, phases=phases)
+                if from_version > to_version:
+                    # We are backporting bug fixes to older releases than the current one.
+                    raise NotImplementedError('backports are not implemented yet')
 
-            # Seed the release with initial project
-            rel.get_project(project).to_version = to_version
+                phases = graph.upgrade_phases(about_project.package)
+                phases = (
+                    (db.get_project_by_package(pkg) for pkg in sorted(phase))
+                    for phase in phases
+                )
+                phases = [PhaseState.clean(projs, db) for projs in phases]
+                assert len(phases) > 0
+                for phase in phases:
+                    allPhases.append(phase)
 
-            # If we are releasing already manually released source version,
-            # then simulate brand new release to bump its dependencies
-            if from_version == to_version:
-                rel.get_project(project).from_version = _previous_version(to_version)
-                ignore.add(project)
+            rel = cls(sources=sources, phases=allPhases)
+
+            for project, to_version in sources.items():
+                # Seed the release with initial project
+                rel.get_project(project).to_version = to_version
+
+                # If we are releasing already manually released source version,
+                # then simulate brand new release to bump its dependencies
+                if from_version == to_version:
+                    rel.get_project(project).from_version = _previous_version(to_version)
+                    ignore.add(project)
 
             rel._build_plan(db, graph)
-            # modify the final release plan so that all mentions of `VIRTUAL_NODE` are removed
-            v_pkg = db.get_project_by_package(VIRTUAL_NODE)
-            ignore.add(v_pkg)
+            # modify the final release plan so that all mentions of `VIRTUAL_ROOT` are removed
             rel._prune_unchanged(ignore=ignore)
             return rel
 
@@ -280,7 +280,7 @@ class ReleaseState(ConfigFile, Checksumable):
 
         pruned_phases = (
             PhaseState([
-                self._delete_virtual_updates(project)
+                project
                 for project in phase
                 if not self._is_project_noop(project) and project.project not in ignore])
             for phase in self.phases
@@ -293,16 +293,6 @@ class ReleaseState(ConfigFile, Checksumable):
             return True
         else:
             return False
-    
-    @classmethod
-    def _delete_virtual_updates(cls, project: 'ProjectState') -> 'ProjectState':
-        pruned_updates = [
-            update
-            for update in project.dependency_updates
-            if update.name != VIRTUAL_NODE
-        ]
-        project.dependency_updates = pruned_updates
-        return project
 
 @dataclass
 class PhaseState(Collection['ProjectReleaseState'], Checksumable):

--- a/sebex/release/state.py
+++ b/sebex/release/state.py
@@ -14,7 +14,7 @@ from sebex.analysis.version import Bump, VersionRequirement, VersionSpec, Versio
 from sebex.checksum import Checksum, Checksumable
 from sebex.config.file import ConfigFile
 from sebex.config.format import Format, YamlFormat
-from sebex.config.manifest import ProjectHandle
+from sebex.config.manifest import Manifest, ProjectHandle
 from sebex.edit.span import Span
 from sebex.log import operation, error, warn
 
@@ -293,6 +293,7 @@ class ReleaseState(ConfigFile, Checksumable):
             return True
         else:
             return False
+            
 
 @dataclass
 class PhaseState(Collection['ProjectReleaseState'], Checksumable):
@@ -426,13 +427,17 @@ class ProjectState(Checksumable):
     @classmethod
     def clean(cls, project: ProjectHandle, db: AnalysisDatabase) -> 'ProjectState':
         about = db.about(project)
+        manifest = Manifest.open()
+        publish = about.is_published or \
+                  manifest.force_publish(project.repo) or \
+                  manifest.force_publish_all
         return cls(
             project=project,
             from_version=about.version,
             to_version=about.version,
             version_span=about.version_span,
             language=db.language(project),
-            publish=about.is_published,
+            publish=publish,
         )
 
     def checksum(self, hasher):


### PR DESCRIPTION
- when packages with obsolete dependencies are encountered they will be updated automatically (previously a warning was thrown)
- packages marked as prerelease should never be bumped unless specified as source
- obsolete packages that are more than one dependency relation removed from a bumped package should not be updated i.e. don't update obsolete packages that are not directly relevant to the current release
- updating obsolete packages should 